### PR TITLE
Tests secretos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+#object files
+*.o
+
+#ejecutables
+*.exe
+

--- a/TPI/TPI-tests/test_suites.cpp
+++ b/TPI/TPI-tests/test_suites.cpp
@@ -1218,6 +1218,20 @@ void iniciarTestsEjercicio11(void) {
 		-1, -1, -1, 1, 1, 1, -1, -1, -1, 1, 1};
 	test_ejercicio11.push_back(TestEjercicio11(nom, s, p, f, R, esperado));
 
+	// Caso 6, r=4
+	nom = "filtradoMediana/segnalDesordenadaR4";
+	p = 16;
+	f = 10;
+	R = 4;
+
+	s = {54, 23, -65, 90, -42, -20, 10, 67, 89, -33, -14, -23, 11,
+		28, 28, 65, 31, 74, 19, -58, -72, -98, -102, 34, 71, -35, 77,
+		13, -46};
+	esperado = {54, 23, -65, 90, 23, 10, -14, -14, -14, 10,
+		11, 28, 28, 28, 28, 28, 28, 28, 19, 19, 19, -35, -35,
+		-35, -35, -35, 77, 13, -46};
+	test_ejercicio11.push_back(TestEjercicio11(nom, s, p, f, R, esperado));
+
 	int cant_de_tests = test_ejercicio11.size();
 	int cant_de_tests_que_pasaron = 0;
 	for(int i=0; i<cant_de_tests; i++){

--- a/TPI/TPI-tests/test_suites.cpp
+++ b/TPI/TPI-tests/test_suites.cpp
@@ -1232,6 +1232,21 @@ void iniciarTestsEjercicio11(void) {
 		-35, -35, -35, 77, 13, -46};
 	test_ejercicio11.push_back(TestEjercicio11(nom, s, p, f, R, esperado));
 
+	// Caso 7, r=4 con ruido
+	nom = "filtradoMediana/segnalDesordenadaR4ConRuido";
+	p = 16;
+	f = 10;
+	R = 4;
+	s = {154, -230, -165, 190,
+		-42, -20, 10, 67, 89, -133, -14, -23, 11, 128, 28,
+		65, 31, 74, 19, -158, -172, -98, -102, 34, 71,
+		-135, 177, 113, -146};
+	esperado = {154, -230, -165, 190,
+		10, -20, -14, -14, -14, 10, 11, 28, 28, 28 , 28,
+		28, 28, 28, 19, 19, 19, -98, -98, -98, -98,
+		-135, 177, 113, -146};
+	test_ejercicio11.push_back(TestEjercicio11(nom, s, p, f, R, esperado));
+
 	int cant_de_tests = test_ejercicio11.size();
 	int cant_de_tests_que_pasaron = 0;
 	for(int i=0; i<cant_de_tests; i++){

--- a/TPI/main.cpp
+++ b/TPI/main.cpp
@@ -13,13 +13,11 @@
 
 using namespace std;
 
-
 int main(int argc, char **argv) {
     std::cout << "Implementando TPI!!" << std::endl;
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-
 
 /*
 int main(void){

--- a/TPI/tests/ej11secretos.cpp
+++ b/TPI/tests/ej11secretos.cpp
@@ -1,0 +1,19 @@
+#include "gtest/gtest.h"
+#include "../ejercicios.h"
+
+TEST(filtradoMediana, senialDesordenadaR4) {
+	int p = 16;
+	int f = 10;
+	int R = 4;
+
+	senial s = {54, 23, -65, 90, -42, -20, 10, 67, 89, -33, -14, -23, 11,
+		28, 28, 65, 31, 74, 19, -58, -72, -98, -102, 34, 71, -35, 77,
+		13, -46};
+
+	filtradoMediana(s, R, p, f);
+	senial esperada = {54, 23, -65, 90, 23, 10, -14, -14, -14, 10,
+		11, 28, 28, 28, 28, 28, 28, 28, 19, 19, 19, -35, -35,
+		-35, -35, -35, 77, 13, -46};
+
+	EXPECT_EQ(esperada, s);
+}

--- a/TPI/tests/ej11secretos.cpp
+++ b/TPI/tests/ej11secretos.cpp
@@ -17,3 +17,22 @@ TEST(filtradoMediana, senialDesordenadaR4) {
 
 	EXPECT_EQ(esperada, s);
 }
+
+TEST(filtradoMediana, senialDesordenadaR4ConRuido) {
+	int p = 16;
+	int f = 10;
+	int R = 4;
+
+	senial s = {154, -230, -165, 190,
+		-42, -20, 10, 67, 89, -133, -14, -23, 11, 128, 28,
+		65, 31, 74, 19, -158, -172, -98, -102, 34, 71,
+		-135, 177, 113, -146};
+
+	filtradoMediana(s, R, p, f);
+	senial esperada = {154, -230, -165, 190,
+		10, -20, -14, -14, -14, 10, 11, 28, 28, 28 , 28,
+		28, 28, 28, 19, 19, 19, -98, -98, -98, -98,
+		-135, 177, 113, -146};
+
+	EXPECT_EQ(esperada, s);
+}


### PR DESCRIPTION
Se agrega un archivo con casos de test creados a partir de los tests secretos en el informe de entrega. Los casos de test agregados se encuentran en [ej11secretos.cpp](TPI/tests/ej11secretos.cpp).  Estos casos sólo aplican al ejercicio 11 y son:
- filtradoMediana/segnalDesordenadaR4 y
- filtradoMediana/segnalDesordenadaR4ConRuido
Las mismas modificaciones se encuentran en el archivo correspondiente [test_suites.cpp](TPI/TPI-tests/test_suites.cpp).